### PR TITLE
Remove ignoreVersionMismatch from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=3.0.0
-ignoreVersionMismatch=true
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
 swaggerVersion=2.2.9


### PR DESCRIPTION
## Purpose
Removes ignoreVersionMismatch property from gradle.properties making the build fail if there is a version mismatch between the installed and set ballerina versions.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
